### PR TITLE
Cycles not dict

### DIFF
--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -760,7 +760,9 @@ def distinct_permutations(iterable, r=None):
         equivalent_items = {k: cycle(v) for k, v in indices_dict.items()}
 
         def permuted_items(permuted_indices):
-            return tuple(next(equivalent_items[index]) for index in permuted_indices)
+            return tuple(
+                next(equivalent_items[index]) for index in permuted_indices
+            )
 
     size = len(items)
     if r is None:

--- a/more_itertools/more.py
+++ b/more_itertools/more.py
@@ -757,9 +757,10 @@ def distinct_permutations(iterable, r=None):
         indices = [items.index(item) for item in items]
         indices.sort()
 
+        equivalent_items = {k: cycle(v) for k, v in indices_dict.items()}
+
         def permuted_items(permuted_indices):
-            dict_ = {k: iter(v) for k, v in indices_dict.items()}
-            return tuple(next(dict_[index]) for index in permuted_indices)
+            return tuple(next(equivalent_items[index]) for index in permuted_indices)
 
     size = len(items)
     if r is None:


### PR DESCRIPTION

### Changes
Memory optimisation.  Uses the same dict of `cycle` iterators for each call to permuted_items function, instead of createing a new dict for every call.

